### PR TITLE
Using parse instead of parse!

### DIFF
--- a/src/devmail.cr
+++ b/src/devmail.cr
@@ -15,7 +15,7 @@ verbose = options.fetch("verbose", false) == "true"
 smtp_port = options.fetch("smtp_port", 25).to_i
 pop3_port = options.fetch("pop3_port", 110).to_i
 
-OptionParser.parse! do |parser|
+OptionParser.parse do |parser|
   parser.banner = "Usage: #{program} [options]"
 
   parser.on("-h", "--help", "Display this screen") do


### PR DESCRIPTION
[Changelog](https://github.com/crystal-lang/crystal/blob/master/CHANGELOG.md)
Deprecation of OptionsParser.parse! in version 0.31.0

Fixes issue: #4 