### PR TITLE
Quit faster when running in docker container.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,4 +10,4 @@ WORKDIR /root/
 COPY --from=build /root/devmail ./
 EXPOSE 110
 EXPOSE 25
-CMD ["./devmail"]
+ENTRYPOINT ["./devmail"]

--- a/src/devmail.cr
+++ b/src/devmail.cr
@@ -1,4 +1,5 @@
 require "option_parser"
+require "signal"
 require "./devmail/config"
 require "./devmail/store"
 require "./devmail/smtp_server"
@@ -41,6 +42,10 @@ if verbose
 else
   Log.setup(:info, Log::IOBackend.new(formatter: ExtraShort))
 end
+
+Signal::INT.trap { exit }
+Signal::TERM.trap { exit }
+Signal::QUIT.trap { exit }
 
 store = Store.new
 smtp_server = SMTPServer.new(store, smtp_port)

--- a/src/devmail/version.cr
+++ b/src/devmail/version.cr
@@ -1,3 +1,3 @@
 module Devmail
-  VERSION = "0.1.0"
+  VERSION = "0.1.1"
 end


### PR DESCRIPTION
I have this "issue" where stopping devmail in a docker container always takes up 10 seconds; while if I run it outside the container it quits immediately. I hope this will improve that.

Note that 10 seconds is [the time-out](https://vsupalov.com/docker-compose-stop-slow/) that's used by docker before it sends a KILL.